### PR TITLE
Added optional rustls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/Cargo.lock
+/target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rustls = ["tokio-tungstenite/__rustls-tls"]
 futures = {version = "0.3", default-features = false, features = ["async-await", "std"]}
 tokio = {version = "1.0", default-features = false, features = ["rt", "time"]}
 tracing = {version = "0.1", default-features = false, features = ["std"]}
-tokio-tungstenite = {version = "0.18", default-features = false, features = ["connect"]}
+tokio-tungstenite = {version = "0.19", default-features = false, features = ["connect"]}
 
 [dev-dependencies]
 rand = {version = "0.8", default-features = false, features = ["std", "std_rng"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 
 [features]
 test = []
+rustls = ["tokio-tungstenite/__rustls-tls"]
 
 [dependencies]
 futures = {version = "0.3", default-features = false, features = ["async-await", "std"]}


### PR DESCRIPTION
This is related to my issue on the `apca` crate. I added a feature that enables `rustls` for `tokio-tungstenite`.